### PR TITLE
Fix: Confirm Button Countdown Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "srf-feathers",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "build/index.js",
   "module": "build/index.esm.js",
   "files": [

--- a/src/elements/ConfirmButton/ConfirmButton.tsx
+++ b/src/elements/ConfirmButton/ConfirmButton.tsx
@@ -26,7 +26,7 @@ const ConfirmButton: React.FC<ConfirmButtonProps> = ({
   icon,
 }) => {
   const [confirming, setConfirming] = useState(false);
-  const [disabledCountdown, setDisabledCountdown] = useState(3);
+  const [disabledCountdown, setDisabledCountdown] = useState(0);
 
   useEffect(() => {
     if (disabledCountdown > 0) {


### PR DESCRIPTION
I fixed a bug where the Countdown of a Confirm Button would always be displayed on the first press.